### PR TITLE
Added the Nextcloud Validation API

### DIFF
--- a/gsoc2018/Nextcloud OAuth Validation API User-saml/checkuser.php
+++ b/gsoc2018/Nextcloud OAuth Validation API User-saml/checkuser.php
@@ -1,0 +1,136 @@
+<?php
+include('connect.php');
+include('config.php'); 
+header("Content-Type:application/json"); 
+//Process the client request
+if(!empty($_POST['username']) && !empty($_POST['token'])){
+	
+	$user=$_POST['username'];
+	$token=$_POST['token'];
+		
+	if(validate_token($token, $clientsecret, $introspurl, $clientid,$tokentype)){	
+			
+		if(checkuserexist($user,$conn)) {
+			updateusertoken($token, $user,$conn);
+			deliver_response(200, "Token Validated and Updated Successfully", NULL);
+		}
+		else {
+			insertusertoken($token, $user, $conn);
+			deliver_response(200, "Token Validated and Creater User Successfully", NULL);
+		}
+	}
+	else {
+		deliver_response(401,"Unauthorized: Invalid Token",$token);	
+	}
+	
+	//validate_token($token, $clientsecret, $introspurl, $clientid,$tokentype);	
+}
+
+else 
+{
+	//throw the invalid request exception
+	deliver_response(400, "Invalid Request", NULL);
+        	
+}
+	
+function deliver_response($status, $status_message, $data){
+	
+	header("HTTP/1.1 $status $status_message");	
+	$response['status'] = $status;
+	$response['status_message']=$status_message;
+	$response['data']=$data;
+	$json_response=json_encode($response);
+	echo $json_response;
+}
+
+//This function validates the token using the introspection endpoint of the 
+//keycloak configured in the server 
+function validate_token($token, $clientsecret, $introspurl, $clientid,$tokentype)
+{
+        $post_url = $introspurl;
+        $curl = curl_init($post_url);
+        $fields = array(
+                        'client_id' => $clientid,
+                        'client_secret' => $clientsecret,
+                        'token_type_hint' => $tokentype,
+                        'token' => $token
+                        );
+	//Url-ify the data to prepare for the post request
+        $fields_string = http_build_query($fields);
+	//Open the connection	
+	$ch = curl_init();
+	
+	//now set the url
+	curl_setopt($ch, CURLOPT_URL, $post_url);
+	curl_setopt($ch, CURLOPT_POST, 4);
+	curl_setopt($ch, CURLOPT_POSTFIELDS,$fields_string);
+	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+	curl_setopt($ch,CURLOPT_SSL_VERIFYPEER, false);
+	//execute the post request
+	$result = curl_exec($ch);
+	//echo $result;
+	$result_json = json_decode($result,true);
+	//var_dump($result_json);
+	$result_boolean = $result_json["active"];
+	return $result_boolean;
+}
+
+//function to check if the user is already authenticated and has logged in once 
+//in the keycloak so that only the token with respect to that particular userid can 
+//be updated into the token table
+
+function checkuserexist($uid, $conn)
+{  
+
+	$query = "SELECT * FROM oc_user_saml_auth_token WHERE uid = '".$uid."'";
+        $result = mysqli_query($conn,$query);
+        if(!mysqli_num_rows($result)>=1) {
+        	return false;
+        }
+        return true;
+}
+//function to update the token in the oc_user_saml_token table if the token is 
+//present in the table
+function updateusertoken($token, $uid, $conn)
+{
+	$token_to_hash=substr($token, -72);
+	//echo $token_to_hash;
+	$token_hash = password_hash($token_to_hash, PASSWORD_DEFAULT);
+		
+	$query= "UPDATE oc_user_saml_auth_token SET token = '".$token_hash."' WHERE uid = '".$uid."'";
+	
+	if (!mysqli_query($conn, $query)) {
+    		return false;
+	} 
+	return true;	
+}
+
+function insertusertoken($token, $uid, $conn)
+{
+        //Create User before inserting the token 
+	if(!createuser($uid, $conn)) {
+	 	return false;
+	}
+	//Hash the token before inserting it into the database
+	$token_to_hash=substr($token, -72);
+	//echo $token_to_hash;
+        $token_hash = password_hash($token_to_hash, PASSWORD_DEFAULT);
+        $query= "INSERT INTO oc_user_saml_auth_token (uid, name, token) VALUES ('".$uid."', '".$uid."', '".$token_hash."')";
+
+        if (!mysqli_query($conn, $query)) {
+		return false;
+        }
+    		return true;
+}
+
+function createuser($uid, $conn)
+{
+	$query = "INSERT INTO oc_user_saml_users (uid, displayname) VALUES ('".$uid."', '".$uid."')";
+	 
+	if (!mysqli_query($conn, $query)) {
+                return false;
+        }
+        return true;
+}
+
+?>

--- a/gsoc2018/Nextcloud OAuth Validation API User-saml/config.php
+++ b/gsoc2018/Nextcloud OAuth Validation API User-saml/config.php
@@ -1,0 +1,10 @@
+<?php
+$dbhost = 'localhost';
+$dbuser = 'nextcloud';
+$database = 'nextcloud';
+$dbpassword = '';
+$clientsecret = '5d2dc66a-f54e-4fa9-b78f-80d33aa862c1';
+$introspurl = 'https://iamdev.scigap.org/auth/realms/seagrid/protocol/openid-connect/token/introspect';
+$clientid = 'pga';
+$tokentype = 'access_token';
+?>

--- a/gsoc2018/Nextcloud OAuth Validation API User-saml/connect.php
+++ b/gsoc2018/Nextcloud OAuth Validation API User-saml/connect.php
@@ -1,0 +1,15 @@
+<?php
+ include('config.php');
+
+ 	$servername = $dbhost;
+        $username = $dbuser;
+        $password = $dbpassword;
+        $db = $database;
+        // Create connection
+        $conn = new mysqli($servername, $username, $password,$db);
+        // Check connection
+        if ($conn->connect_error) {
+                die("Connection failed: " . $conn->connect_error);
+        }             
+?>
+

--- a/gsoc2018/Nextcloud OAuth Validation API User-saml/readme.txt
+++ b/gsoc2018/Nextcloud OAuth Validation API User-saml/readme.txt
@@ -1,0 +1,15 @@
+## Steps to Use the Validation API
+
+- This is the validation API for the nextcloud to enable the backend programs to authenticate to the nextcloud instance via the OAuth token through WebDAV.
+
+-This is the POST API and takes the input as the username and token, then returns 200 response if the authentication is successfull else returns 401 unauthorized response.
+
+- Place the checkuser.php API in the server where nextcloud is installed with the configuration files.
+
+- For the API to work the nextcloud should be configured with the Single sign on using the user_saml app along with the keycloak.
+The more information of configuring the nextcloud with the user_saml app and keycloak can be found at the following link:
+https://stackoverflow.com/a/48400813/3446129 https://docs.nextcloud.com/server/11/admin_manual/configuration_server/sso_configuration.html 
+
+- The introspection endpoint should be updated in the config.php, along with the other configurations settings with respect to the keycloak and the nextcloud database.
+
+


### PR DESCRIPTION
- This is the validation API for the nextcloud to enable the backend programs to authenticate to the nextcloud instance via the OAuth token through WebDAV.

- This is the POST API and takes the input as the username and token, then returns 200 response if the authentication is successfull else returns 401 unauthorized response.

- This API was developed for the phase 1 GSoC 2018 and later the same code is utilized to add the functionality of API to the airavata-nextcloud app at the link: https://github.com/DImuthuUpe/airavata-nextcloud-app/pull/1

